### PR TITLE
구글 시트 UI 향상을 위해 `ExecutionTimeLog`의 BatchProcessType 저장 방식 수정

### DIFF
--- a/src/main/java/com/example/review_study_app/common/aop/JobLoggingAspect.java
+++ b/src/main/java/com/example/review_study_app/common/aop/JobLoggingAspect.java
@@ -40,7 +40,7 @@ public class JobLoggingAspect {
         this.logGoogleSheetsRepository = logGoogleSheetsRepository;
     }
 
-    @Around("execution(* com.example.review_study_app.github.GithubJobFacade.*(..))")
+    @Around("execution(* com.example.review_study_app.github.GithubJobFacade.*(..))") // TODO : JobLogging 어노테이션 붙은 클래스의 모든 메서드에서 동작되도록 수정하기
     public Object logAroundMethods(ProceedingJoinPoint joinPoint) throws Throwable {
         long startTime = System.currentTimeMillis();
 
@@ -76,7 +76,7 @@ public class JobLoggingAspect {
 
             logGoogleSheetsRepository.save(jobDetailLog);
 
-            ExecutionTimeLog executionTimeLog = new ExecutionTimeLog(
+            ExecutionTimeLog executionTimeLog = ExecutionTimeLog.of(
                 BatchProcessIdContext.getJobId(),
                 null,
                 logHelper.getEnvironment(),
@@ -121,7 +121,7 @@ public class JobLoggingAspect {
 
             logGoogleSheetsRepository.save(jobDetailLog);
 
-            ExecutionTimeLog executionTimeLog = new ExecutionTimeLog(
+            ExecutionTimeLog executionTimeLog = ExecutionTimeLog.of(
                 BatchProcessIdContext.getJobId(),
                 null,
                 logHelper.getEnvironment(),

--- a/src/main/java/com/example/review_study_app/common/aop/StepLoggingAspect.java
+++ b/src/main/java/com/example/review_study_app/common/aop/StepLoggingAspect.java
@@ -83,7 +83,7 @@ public class StepLoggingAspect {
 
             logGoogleSheetsRepository.save(stepDetailLog);
 
-            ExecutionTimeLog executionTimeLog = new ExecutionTimeLog(
+            ExecutionTimeLog executionTimeLog = ExecutionTimeLog.of(
                 stepId,
                 parentId,
                 environment,
@@ -128,7 +128,7 @@ public class StepLoggingAspect {
 
             logGoogleSheetsRepository.save(stepDetailLog);
 
-            ExecutionTimeLog executionTimeLog = new ExecutionTimeLog(
+            ExecutionTimeLog executionTimeLog = ExecutionTimeLog.of(
                 stepId,
                 parentId,
                 environment,

--- a/src/main/java/com/example/review_study_app/common/aop/TaskRestTemplateLoggingAspect.java
+++ b/src/main/java/com/example/review_study_app/common/aop/TaskRestTemplateLoggingAspect.java
@@ -103,7 +103,7 @@ public class TaskRestTemplateLoggingAspect {
 
                 logGoogleSheetsRepository.save(githubApiLog);
 
-                ExecutionTimeLog executionTimeLog = new ExecutionTimeLog(
+                ExecutionTimeLog executionTimeLog = ExecutionTimeLog.of(
                     batchProcessId,
                     parentId,
                     logHelper.getEnvironment(),
@@ -146,7 +146,7 @@ public class TaskRestTemplateLoggingAspect {
 
                 logGoogleSheetsRepository.save(githubApiLog);
 
-                ExecutionTimeLog executionTimeLog = new ExecutionTimeLog(
+                ExecutionTimeLog executionTimeLog = ExecutionTimeLog.of(
                     batchProcessId,
                     parentId,
                     logHelper.getEnvironment(),

--- a/src/main/java/com/example/review_study_app/log/ExecutionTimeLog.java
+++ b/src/main/java/com/example/review_study_app/log/ExecutionTimeLog.java
@@ -8,8 +8,8 @@ import com.example.review_study_app.github.BatchProcessStatus;
  *
  * @param id : 식별자
  * @param parentId : 부모 식별자 (예 : Step의 경우 jobId, Task의 경우 taskId)
+ * @param job, step, task : 배치 프로세스가 자신의 해당한 값을 갖는다. -> BatchProcessType를 구글 시트에서 보기 편하도록 나눔!
  * @param environment : 개발환경 (예 : local)
- * @param batchProcessType : 배치 프로세스 유형 (예 : JOB, STEP, TASK)
  * @param batchProcessName : 배치 프로세스 이름 (예 : 각 배치 프로세스 클래스의 메서드 이름)
  * @param batchProcessStatus : 배치 프로세스 상태 (예 : 완료/중지)
  * @param batchProcessStatusReason : 배치 프로세스 상태 이유 (예 : 성공/예외 발생)
@@ -21,7 +21,9 @@ public record ExecutionTimeLog<T>(
     String id,
     String parentId,
     String environment,
-    BatchProcessType batchProcessType,
+    String job,
+    String step,
+    String task,
     String batchProcessName,
     BatchProcessStatus batchProcessStatus,
     String batchProcessStatusReason,
@@ -30,4 +32,76 @@ public record ExecutionTimeLog<T>(
     String createdAt
 ) {
 
+    /**
+     * < 정적 팩토리 패턴을 적용한 이유 >
+     * - 정적 팩토리 패턴을 적용한 이유는 필드 수정에 따른 수정 작업을 더 간단히 하고 싶었기 때문이다.
+     * - 수정 하는 방법에는 크게 2가지를 생각했다.
+     * 방법 1. 추가로 정적 팩토리 패턴을 활용하지 않고, ExecutionTimeLog 사용 중인 곳을 찾아서 수정된 필드들을 수정하는 방법
+     * 방법 2. 정잭 팩토리 패턴을 활용하여, ExecutionTimeLog 사용 중인 곳을 찾아서, 기존에 생성자 방식을 정적 팩토리 패턴 적용 방식으로 변경하는 방법
+     *
+     * - 방법 1로 수정할 경우, Job, Step, Task 각각에 따라 하나하나 상황에 맞게 바꿔줘야 했고, 오타로 BatchProcessType 외의 값이 들어갈 수 있는 가능성이 있다.
+     * - 반면, 방법 2는 기존 생성자의 선언 순서는 그대로 하되, 일괄적으로 new ExecutionTimeLog 를 ExecutionTimeLog.of로 바꿔주기만 하면 된다.
+     * - 또한, BatchProcessType 외의 값이 들어갈 오류도 없어, 방법 1 보다 안정적으로 수정할 수 있다는 점에서 방법 2를 택했다.
+     */
+    public static ExecutionTimeLog of(
+        String id,
+        String parentId,
+        String environment,
+        BatchProcessType batchProcessType,
+        String batchProcessName,
+        BatchProcessStatus batchProcessStatus,
+        String batchProcessStatusReason,
+        Long detailLogId,
+        long executionTime,
+        String createdAt
+    ) {
+        if(batchProcessType.equals(BatchProcessType.JOB)) {
+            return new ExecutionTimeLog(
+                id,
+                parentId,
+                environment,
+                batchProcessType.name(),
+                "",
+                "",
+                batchProcessName,
+                batchProcessStatus,
+                batchProcessStatusReason,
+                detailLogId,
+                executionTime,
+                createdAt
+            );
+        } else if(batchProcessType.equals(BatchProcessType.STEP)) {
+            return new ExecutionTimeLog(
+                id,
+                parentId,
+                environment,
+                "",
+                batchProcessType.name(),
+                "",
+                batchProcessName,
+                batchProcessStatus,
+                batchProcessStatusReason,
+                detailLogId,
+                executionTime,
+                createdAt
+            );
+        } else if(batchProcessType.equals(BatchProcessType.TASK)) {
+            return new ExecutionTimeLog(
+                id,
+                parentId,
+                environment,
+                "",
+                "",
+                batchProcessType.name(),
+                batchProcessName,
+                batchProcessStatus,
+                batchProcessStatusReason,
+                detailLogId,
+                executionTime,
+                createdAt
+            );
+        } else {
+            throw new RuntimeException("알 수 없는 ~");
+        }
+    }
 }


### PR DESCRIPTION
`ExecutionTimeLog`의 BatchProcessType 저장 방식 수정

- 구글 시트에서 보기 편하도록 BatchProcessType 값 다 펼쳐서 저장함.
- 수정 작업을 좀더 간단히 하고자 정적 팩토리 패턴으로 객체 생성 방식 변경함.