### PR TITLE
JSON 파싱 에러 해결

### DIFF
--- a/src/main/java/com/example/review_study_app/common/service/log/LogGoogleSheetsRepository.java
+++ b/src/main/java/com/example/review_study_app/common/service/log/LogGoogleSheetsRepository.java
@@ -201,10 +201,10 @@ public class LogGoogleSheetsRepository { // TODO : LogRepository 인터페이스
         String keyBody = privateKey.replace(begin, "").replace(end, "").trim();
 
         // Add new lines to the key body
-        keyBody = keyBody.replace(" ", "\n");
+        keyBody = keyBody.replace(" ", "\\n");
 
         // Reconstruct the private key with new lines
-        return begin + "\n" + keyBody + "\n" + end + "\n";
+        return begin + "\\n" + keyBody + "\\n" + end + "\\n";
     }
 
     private Sheets createSheets() throws IOException, GeneralSecurityException {


### PR DESCRIPTION
- 에러 메시지 : `Illegal unquoted character ((CTRL-CHAR, code 10)): has to be escaped using backslash to be included in string value`
- JSON 파서가 JSON 문자열 내에 허용되지 않는 문자가 포함되어 있음을 나타낸다.
- 특히, 제어 문자(예: 줄바꿈 문자 \n 등)는 JSON 문자열 내에서 직접 사용할 수 없고, 반드시 백슬래시를 사용하여 이스케이프 처리해야 한다.
-  따라서, 해결 방법은 \n 문자를 문자열 내에 직접 포함하는 대신, JSON 구문을 따르도록 문자열을 이스케이프 처리하는 것이다. 예를 들어, Java에서 이 문제를 해결하기 위해서는 \n 문자를 \\n로 이스케이프해야 한다.