### PR TITLE
`get` 통신 로깅 안되는 문제 해결

### DIFF
--- a/src/main/java/com/example/review_study_app/common/service/log/DirectSaveLogService.java
+++ b/src/main/java/com/example/review_study_app/common/service/log/DirectSaveLogService.java
@@ -99,6 +99,8 @@ public class DirectSaveLogService implements LogService {
 
             MyHttpResponse myHttpResponse = (MyHttpResponse) saveTaskLogDto.taskResult();
 
+            String requestBody = saveTaskLogDto.myHttpRequest().body() != null ? saveTaskLogDto.myHttpRequest().body().toString() : null;
+
             logGoogleSheetsRepository.save(new GithubApiLog(
                 taskDetailLogId,
                 logHelper.getEnvironment(),
@@ -106,7 +108,7 @@ public class DirectSaveLogService implements LogService {
                 saveTaskLogDto.httpMethod(),
                 saveTaskLogDto.myHttpRequest().url(),
                 saveTaskLogDto.myHttpRequest().headers(),
-                saveTaskLogDto.myHttpRequest().body().toString(),
+                requestBody,
                 myHttpResponse.statusCode(),
                 myHttpResponse.headers(),
                 myHttpResponse.body(),
@@ -116,6 +118,8 @@ public class DirectSaveLogService implements LogService {
         } else if(saveTaskLogDto.taskResult() instanceof RestClientResponseException) {
             RestClientResponseException restClientResponseException = (RestClientResponseException) saveTaskLogDto.taskResult();
 
+            String requestBody = saveTaskLogDto.myHttpRequest().body() != null ? saveTaskLogDto.myHttpRequest().body().toString() : null;
+
             logGoogleSheetsRepository.save(new GithubApiLog(
                 taskDetailLogId,
                 logHelper.getEnvironment(),
@@ -123,7 +127,7 @@ public class DirectSaveLogService implements LogService {
                 saveTaskLogDto.httpMethod(),
                 saveTaskLogDto.myHttpRequest().url(),
                 saveTaskLogDto.myHttpRequest().headers(),
-                saveTaskLogDto.myHttpRequest().body().toString(),
+                requestBody,
                 restClientResponseException.getStatusCode().value(),
                 restClientResponseException.getResponseHeaders(),
                 restClientResponseException.getResponseBodyAsString(),


### PR DESCRIPTION
- `saveTaskLogDto.myHttpRequest().body()`가 null일 경우 예외가 발생해서 안되는 것이었음