### PR TITLE
Resttemplate 로깅 방법을 AOP -> Interceptor 방법으로 수정

### DIFF
--- a/src/main/java/com/example/review_study_app/common/config/AppConfig.java
+++ b/src/main/java/com/example/review_study_app/common/config/AppConfig.java
@@ -1,15 +1,28 @@
 package com.example.review_study_app.common.config;
 
+import com.example.review_study_app.common.service.log.LogService;
+import com.example.review_study_app.task.httpclient.RestTemplateLoggingGitHubApiInterceptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
+
+    private final LogService logService;
+
+    @Autowired
+    public AppConfig(LogService logService) {
+        this.logService = logService;
+    }
 
     /**
      *
@@ -29,6 +42,8 @@ public class AppConfig {
     @Bean
     public RestTemplate restTemplate() {
         RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
+        restTemplate.setInterceptors(Collections.singletonList(new RestTemplateLoggingGitHubApiInterceptor(logService)));
         restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
         return restTemplate;
     }

--- a/src/main/java/com/example/review_study_app/common/service/log/dto/SaveTaskLogDto.java
+++ b/src/main/java/com/example/review_study_app/common/service/log/dto/SaveTaskLogDto.java
@@ -1,16 +1,18 @@
 package com.example.review_study_app.common.service.log.dto;
 
 import com.example.review_study_app.common.enums.BatchProcessStatus;
-import com.example.review_study_app.task.httpclient.dto.MyHttpRequest;
+import org.springframework.http.HttpHeaders;
 
 public record SaveTaskLogDto<T>(
-    String batchProcessName,
     BatchProcessStatus status,
     String statusReason,
     String httpMethod,
-    MyHttpRequest myHttpRequest,
-
-    T taskResult,
+    String url,
+    HttpHeaders requestHeaders,
+    String requestBody,
+    int responseStatusCode,
+    HttpHeaders responseHeaders,
+    String responseBody,
     long startTime,
     long endTime
 ) {

--- a/src/main/java/com/example/review_study_app/task/httpclient/RestTemplateLoggingGitHubApiInterceptor.java
+++ b/src/main/java/com/example/review_study_app/task/httpclient/RestTemplateLoggingGitHubApiInterceptor.java
@@ -1,0 +1,96 @@
+package com.example.review_study_app.task.httpclient;
+
+import com.example.review_study_app.common.enums.BatchProcessStatus;
+import com.example.review_study_app.common.service.log.LogService;
+import com.example.review_study_app.common.service.log.dto.SaveTaskLogDto;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.RestClientResponseException;
+
+@Slf4j
+public class RestTemplateLoggingGitHubApiInterceptor implements ClientHttpRequestInterceptor {
+
+    private final LogService logService;
+
+    @Autowired
+    public RestTemplateLoggingGitHubApiInterceptor(
+        LogService logService
+    ) {
+        this.logService = logService;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        long startTime = System.currentTimeMillis();
+
+        String url = request.getURI().toString();
+
+        HttpHeaders requestHeaders = request.getHeaders();
+
+        String requestHttpMethod = request.getMethod().name();
+
+        String requestBody = new String(body, StandardCharsets.UTF_8);
+
+        try {
+
+            ClientHttpResponse response = execution.execute(request, body);
+
+            long endTime = System.currentTimeMillis();
+
+            if (url.contains("api.github.com/repos")) { // TODO : 일단 Github API만, Discord는 추후에 고려. 만약, Discord도 할 때, 클래스명 수정 필요
+
+                saveTaskLog(new SaveTaskLogDto(
+                    BatchProcessStatus.COMPLETED,
+                    "Task 수행 완료",
+                    requestHttpMethod,
+                    url,
+                    requestHeaders,
+                    requestBody,
+                    response.getStatusCode().value(),
+                    response.getHeaders(),
+                    response.getBody().toString(),
+                    startTime,
+                    endTime
+                ));
+            }
+
+            return response;
+        } catch (RestClientResponseException restClientResponseException) {
+            long endTime = System.currentTimeMillis();
+
+            if(url.contains("api.github.com/repos")) { // TODO : 일단 Github API만, Discord는 추후에 고려. 만약, Discord도 할 때, 클래스명 수정 필요
+
+                saveTaskLog(new SaveTaskLogDto(
+                    BatchProcessStatus.STOPPED,
+                    "예외 발생 : "+restClientResponseException.getMessage(),
+                    requestHttpMethod,
+                    url,
+                    requestHeaders,
+                    requestBody,
+                    restClientResponseException.getStatusCode().value(),
+                    restClientResponseException.getResponseHeaders(),
+                    restClientResponseException.getResponseBodyAsString(),
+                    startTime,
+                    endTime
+                ));
+            }
+
+            throw restClientResponseException;
+        } catch (Exception exception) {
+            log.error("{}에서 예상치 못한 예외가 발생했습니다. exception={}", getClass().toString(), exception.getMessage());
+
+            throw exception;
+        }
+    }
+
+    private void saveTaskLog(SaveTaskLogDto saveTaskLogDto) {
+        logService.saveTaskLog(saveTaskLogDto);
+    }
+}

--- a/src/main/java/com/example/review_study_app/task/httpclient/aop/RestTemplateHttpClientTaskLoggingAspect.java
+++ b/src/main/java/com/example/review_study_app/task/httpclient/aop/RestTemplateHttpClientTaskLoggingAspect.java
@@ -19,6 +19,7 @@ import org.springframework.web.client.RestClientResponseException;
 @Aspect
 @Component
 @Order(value = 2)
+@Deprecated
 public class RestTemplateHttpClientTaskLoggingAspect {
 
     private final LogService logService;
@@ -60,16 +61,16 @@ public class RestTemplateHttpClientTaskLoggingAspect {
 
             if(url.contains("api.github.com/repos")) { // TODO : 일단 Github API만, Discord는 추후에 고려. 만약, Discord도 할 때, 클래스명 수정 필요
 
-                saveTaskLog(new SaveTaskLogDto(
-                    batchProcessName,
-                    BatchProcessStatus.COMPLETED,
-                    "Task 수행 완료",
-                    httpMethod,
-                    myHttpRequest,
-                    myHttpResponse,
-                    startTime,
-                    endTime
-                ));
+//                saveTaskLog(new SaveTaskLogDto(
+//                    batchProcessName,
+//                    BatchProcessStatus.COMPLETED,
+//                    "Task 수행 완료",
+//                    httpMethod,
+//                    myHttpRequest,
+//                    myHttpResponse,
+//                    startTime,
+//                    endTime
+//                ));
 
                 return result;
             }
@@ -80,16 +81,16 @@ public class RestTemplateHttpClientTaskLoggingAspect {
 
             if(url.contains("api.github.com/repos")) { // TODO : 일단 Github API만, Discord는 추후에 고려.
 
-                saveTaskLog(new SaveTaskLogDto(
-                    batchProcessName,
-                    BatchProcessStatus.STOPPED,
-                    "예외 발생 : "+restClientResponseException.getMessage(),
-                    httpMethod,
-                    myHttpRequest,
-                    restClientResponseException,
-                    startTime,
-                    endTime
-                ));
+//                saveTaskLog(new SaveTaskLogDto(
+//                    batchProcessName,
+//                    BatchProcessStatus.STOPPED,
+//                    "예외 발생 : "+restClientResponseException.getMessage(),
+//                    httpMethod,
+//                    myHttpRequest,
+//                    restClientResponseException,
+//                    startTime,
+//                    endTime
+//                ));
             }
 
             throw restClientResponseException;


### PR DESCRIPTION
변경 이유
- AOP로 하면 실제 HTTP 통신 헤더 등에 대해 자세히 볼 수 없음.
- 인터셉터를 사용하면, 가능함.