### PR TITLE
`ReviewStudyScheduler`를 local 용과 prod용으로 분리

### DIFF
--- a/src/main/java/com/example/review_study_app/scheduler/ReviewStudyLocalScheduler.java
+++ b/src/main/java/com/example/review_study_app/scheduler/ReviewStudyLocalScheduler.java
@@ -6,34 +6,42 @@ import com.example.review_study_app.common.utils.MyDateUtils;
 import java.time.ZonedDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * ReviewStudyScheduler 는 스케줄링 작업을 수행 책임을 담당하는 클래스이다.
+ * ReviewStudyLocalScheduler 는 Local 용 스케줄링 작업을 수행 책임을 담당하는 클래스이다.
  *
  * < year과 weekNumber를 reviewStudySchedulerFacade 에서 관리할 수 있는데, 여기서 관리하는 이유 >
  * - @scheduled의 cron을 설정할 때, 이번주인지, 다음주인지, 지난주인지에 대해 고려해야 할 때가 있다.
- * - 이를 위해 한 곳에서만 수정 작업을 가능하게 하는게 유지보수성이 더 좋은 것 같아서
+ * - 이럴 때, cron 값에 따라 currentWeekNumber 에 +1, -1 등을 추가해 주어야 한다.
+ * - 만약, year과 weekNumber를 reviewStudySchedulerFacade 에서 관리하면, ReviewStudyScheduler 와 reviewStudySchedulerFacade 2개의 파일을 신경써줘야 한다.
+ * - 반면, 여기서 관리하면, 1곳에서만 수정 작업을 가능하게 되어, 유지보수성이 더 좋은 것 같다고 생각했다.
+ *
+ * < ReviewStudyScheduler를 local 용과 prod용으로 분리한 이유 >
+ * - local 에서 작업할 때, @scheduled의 cron을 설정을 수정할 때가 있다.
+ * - 이때, 수정한 걸 다시 원래 설정으로 바꾸는 걸 계속 까먹거나 번거롭다고 생각해서, 환경별로 파일을 분리했다.
+ *
+ * < application.yml 과 application-local.yml 파일의 값을 활용해서, 환경별로 분리할 수 있는데, 클래스를 분리한 이유 >
+ * - local 작업을 하면서 weekNumber의 값과 @scheduled의 cron의 값을 같이 변경해 볼 때도 있는데, 이때 1곳에서만 변경하도록 하는게 좋을 것 같아서
  */
 
 @Slf4j
 @Component
-public class ReviewStudyScheduler {
+@Profile("local")
+public class ReviewStudyLocalScheduler {
 
     private final ReviewStudySchedulerFacade reviewStudySchedulerFacade;
 
     @Autowired
-    public ReviewStudyScheduler(
+    public ReviewStudyLocalScheduler(
         ReviewStudySchedulerFacade reviewStudySchedulerFacade
     ) {
         this.reviewStudySchedulerFacade = reviewStudySchedulerFacade;
     }
 
-    /**
-     * 매주 월요일 AM 00:10 에 이번주차 Label 을 생성하는 스케줄 함수
-     */
-    @Scheduled(cron = "0 10 0 ? * MON", zone = "Asia/Seoul")
+//    @Scheduled(fixedRate = 60000)
     public void runCreateNewLabel() {
         ZonedDateTime seoulDateTime = ZonedDateTime.now(ZONE_ID_SEOUL);
 
@@ -44,11 +52,7 @@ public class ReviewStudyScheduler {
         reviewStudySchedulerFacade.createNewWeekNumberLabel(currentYear, currentWeekNumber);
     }
 
-    /**
-     * 매주 월요일 AM 00:30 에 모든 멤버의 이번주차 주간회고 Issues 를 생성하는 스케줄 함수
-     */
-//    @Scheduled(cron = "0 30 0 ? * MON", zone = "Asia/Seoul")
-    @Scheduled(fixedRate = 60000) // TODO : 테스트용 20분마다
+//    @Scheduled(fixedRate = 60000)
     public void runCreateNewIssue() {
         ZonedDateTime seoulDateTime = ZonedDateTime.now(ZONE_ID_SEOUL);
 
@@ -59,10 +63,7 @@ public class ReviewStudyScheduler {
         reviewStudySchedulerFacade.createNewWeeklyReviewIssues(currentYear, currentWeekNumber);
     }
 
-    /**
-     * 매주 일요일 PM 11:50 에 이번주 주간회고 이슈를 Close 시키는 스케줄 함수
-     */
-    @Scheduled(cron = "0 50 23 ? * SUN", zone = "Asia/Seoul")
+//    @Scheduled(fixedRate = 60000)
     public void runCloseIssues() {
         ZonedDateTime seoulDateTime = ZonedDateTime.now(ZONE_ID_SEOUL);
 

--- a/src/main/java/com/example/review_study_app/scheduler/ReviewStudyProdScheduler.java
+++ b/src/main/java/com/example/review_study_app/scheduler/ReviewStudyProdScheduler.java
@@ -1,0 +1,73 @@
+package com.example.review_study_app.scheduler;
+
+import static com.example.review_study_app.common.utils.MyDateUtils.ZONE_ID_SEOUL;
+
+import com.example.review_study_app.common.utils.MyDateUtils;
+import java.time.ZonedDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * ReviewStudyProdScheduler 는 Prod 용 스케줄링 작업을 수행 책임을 담당하는 클래스이다.
+ *
+ */
+
+@Slf4j
+@Component
+@Profile("prod")
+public class ReviewStudyProdScheduler {
+
+    private final ReviewStudySchedulerFacade reviewStudySchedulerFacade;
+
+    @Autowired
+    public ReviewStudyProdScheduler(
+        ReviewStudySchedulerFacade reviewStudySchedulerFacade
+    ) {
+        this.reviewStudySchedulerFacade = reviewStudySchedulerFacade;
+    }
+
+    /**
+     * 매주 월요일 AM 00:10 에 이번주차 Label 을 생성하는 스케줄 함수
+     */
+    @Scheduled(cron = "0 10 0 ? * MON", zone = "Asia/Seoul")
+    public void runCreateNewLabel() {
+        ZonedDateTime seoulDateTime = ZonedDateTime.now(ZONE_ID_SEOUL);
+
+        int currentYear = MyDateUtils.getCurrentYear(seoulDateTime);
+
+        int currentWeekNumber = MyDateUtils.getCurrentWeekNumber(seoulDateTime);
+
+        reviewStudySchedulerFacade.createNewWeekNumberLabel(currentYear, currentWeekNumber);
+    }
+
+    /**
+     * 매주 월요일 AM 00:30 에 모든 멤버의 이번주차 주간회고 Issues 를 생성하는 스케줄 함수
+     */
+    @Scheduled(cron = "0 30 0 ? * MON", zone = "Asia/Seoul")
+    public void runCreateNewIssue() {
+        ZonedDateTime seoulDateTime = ZonedDateTime.now(ZONE_ID_SEOUL);
+
+        int currentYear = MyDateUtils.getCurrentYear(seoulDateTime);
+
+        int currentWeekNumber = MyDateUtils.getCurrentWeekNumber(seoulDateTime);
+
+        reviewStudySchedulerFacade.createNewWeeklyReviewIssues(currentYear, currentWeekNumber);
+    }
+
+    /**
+     * 매주 일요일 PM 11:50 에 이번주 주간회고 이슈를 Close 시키는 스케줄 함수
+     */
+    @Scheduled(cron = "0 50 23 ? * SUN", zone = "Asia/Seoul")
+    public void runCloseIssues() {
+        ZonedDateTime seoulDateTime = ZonedDateTime.now(ZONE_ID_SEOUL);
+
+        int currentYear = MyDateUtils.getCurrentYear(seoulDateTime);
+
+        int currentWeekNumber = MyDateUtils.getCurrentWeekNumber(seoulDateTime);
+
+        reviewStudySchedulerFacade.closeWeeklyReviewIssues(currentYear, currentWeekNumber-1);
+    }
+}


### PR DESCRIPTION
- local 에서 작업할 때, @scheduled의 cron을 설정을 수정할 때가 있다.
- 이때, 수정한 걸 다시 원래 설정으로 바꾸는 걸 계속 까먹거나 번거롭다고 생각해서, 환경별로 파일을 분리했다